### PR TITLE
Link to discord directly

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -35,7 +35,7 @@
     <div class="sidebar-section">
         <h4>Contact</h4>
         <nav class="social-links">
-            <p>Discord: syrno9</p>
+            <a href="https://discord.com/users/347168767194955789">Discord</a>
             <a href="mailto:syrno@hikari3.ch">Email</a>
         </nav>
 


### PR DESCRIPTION
Links to discord profile directly (https://discord.com/users/347168767194955789) instead of just having the text "Discord: syrno9"